### PR TITLE
Feature staging branches

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -62,21 +62,22 @@
 #
 #    # Generates an execution plan for Terraform in development
 #    - name: Terraform Plan Development
-#      if: github.ref == env.DEVELOPMENT_REF
+#      # Plan if not on staging branch or tag
+#      if: github.ref != env.STAGING_REF && !startsWith(github.ref, 'refs/tags/v')
 #      run: ./helpers/deploy.sh -a plan -s $DEVELOPMENT_STAGE
 #      env:
 #        GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
 #
 #    # Generates an execution plan for Terraform in staging
 #    - name: Terraform Plan Staging
-#      if: github.ref == env.STAGING_REF
+#      if: github.ref == env.STAGING_REF || github.ref == env.DEVELOPMENT_REF
 #      run: ./helpers/deploy.sh -a plan -s $STAGING_STAGE
 #      env:
 #        GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
 #
 #    # Generates an execution plan for Terraform in production
 #    - name: Terraform Plan Production
-#      if: startsWith(github.ref, 'refs/tags/v')
+#      if: startsWith(github.ref, 'refs/tags/v') || github.ref == env.STAGING_REF
 #      run: ./helpers/deploy.sh -a plan -s $PRODUCTION_STAGE
 #      env:
 #        GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,53 +1,105 @@
-
-# name: 'Terraform'
-
-# on:
-#   push:
-#     branches: [ "main" ]
-#   pull_request:
-
-# permissions:
-#   contents: read
-
-# jobs:
-#   terraform:
-#     name: 'Terraform'
-#     runs-on: ubuntu-latest
-#     environment: production
-
-#     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
-#     defaults:
-#       run:
-#         shell: bash
-
-#     steps:
-#     # Checkout the repository to the GitHub Actions runner
-#     - name: Checkout
-#       uses: actions/checkout@v3
-
-#     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-#     - name: Setup Terraform
-#       uses: hashicorp/setup-terraform@v1
-
-#     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-#     - name: Terraform Init
-#       working-directory: ./terraform
-#       run: terraform init
-#       env: 
-#         GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
-
-#     # Generates an execution plan for Terraform
-#     - name: Terraform Plan
-#       working-directory: ./terraform
-#       run: terraform plan -input=false -var-file="production.tfvars"
-#       env: 
-#         GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
-
-#       # On push to "main", build or change infrastructure according to Terraform configuration files
-#       # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
-#     - name: Terraform Apply
-#       working-directory: ./terraform
-#       if: github.ref == 'refs/heads/"main"' && github.event_name == 'push'
-#       run: terraform apply -auto-approve -input=false -var-file="production.tfvars"
-#       env: 
-#         GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+#name: 'Terraform'
+#
+#on:
+#  push:
+#    tags:
+#      - '*' # Push events to matching v*, i.e. v1.0, v20.15.10
+#    # Allows you to run this workflow manually from the Actions tab
+#    branches:
+#      - '*'
+#  pull_request:
+#  workflow_dispatch:
+#
+#env:
+#  DEVELOPMENT_STAGE: "dev"
+#  PRODUCTION_STAGE: "prd"
+#  STAGING_STAGE: "stg"
+#  DEVELOPMENT_BRANCH: "development"
+#  DEVELOPMENT_REF: "refs/heads/development"
+#  STAGING_BRANCH: "main"
+#  STAGING_REF: "refs/heads/main"
+#
+#
+#permissions:
+#  contents: read
+#
+#jobs:
+#  terraform:
+#    name: 'Terraform'
+#    runs-on: ubuntu-latest
+#    environment: production
+#
+#    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+#    defaults:
+#      run:
+#        shell: bash
+#
+#    steps:
+#    # Checkout the repository to the GitHub Actions runner
+#    - name: Checkout
+#      uses: actions/checkout@v3
+#
+#    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+#    - name: Setup Terraform
+#      uses: hashicorp/setup-terraform@v2
+#
+#    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+#    - name: Terraform Init
+#      working-directory: ./terraform
+#      run: terraform init
+#      env:
+#        GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+#
+#    # Terraform version
+#    - name: Terraform Version
+#      working-directory: ./terraform
+#      run: terraform --version
+#
+#    # Validate the Terraform files
+#    - name: Terraform Validate
+#      working-directory: ./terraform
+#      run: terraform validate
+#
+#    # Generates an execution plan for Terraform in development
+#    - name: Terraform Plan Development
+#      if: github.ref == env.DEVELOPMENT_REF
+#      run: ./helpers/deploy.sh -a plan -s $DEVELOPMENT_STAGE
+#      env:
+#        GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+#
+#    # Generates an execution plan for Terraform in staging
+#    - name: Terraform Plan Staging
+#      if: github.ref == env.STAGING_REF
+#      run: ./helpers/deploy.sh -a plan -s $STAGING_STAGE
+#      env:
+#        GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+#
+#    # Generates an execution plan for Terraform in production
+#    - name: Terraform Plan Production
+#      if: startsWith(github.ref, 'refs/tags/v')
+#      run: ./helpers/deploy.sh -a plan -s $PRODUCTION_STAGE
+#      env:
+#        GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+#
+#      # On push to "main", build or change infrastructure according to Terraform configuration files
+#      # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
+#      # TODO check how to implement strict status check
+#    - name: Terraform Apply Development
+#      if: github.ref == env.DEVELOPMENT_REF
+#      run: ./helpers/deploy.sh -a apply -s $DEVELOPMENT_STAGE -y
+#      env:
+#        GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+#
+#    - name: Terraform Apply Staging
+#      if: github.ref == env.STAGING_REF
+#      run: ./helpers/deploy.sh -a apply -s $STAGING_STAGE -y
+#      env:
+#        GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+#
+#    - name: Terraform Apply Production
+#      # TODO change this job to only deploy to production on new releases, instead of tags
+#      #   See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
+#      if: startsWith(github.ref, 'refs/tags/v')
+#      run: ./helpers/deploy.sh -a apply -s $PRODUCTION_STAGE -y
+#      env:
+#        GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,7 @@
 #
 #.apply:
 #  stage: apply
+#  when: manual
 #  script:
 #    - ./helpers/deploy.sh -a apply -s $TERRAFORM_WORKSPACE
 #

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,29 +1,100 @@
-# image:
-#    name: hashicorp/terraform:light
-#    entrypoint:
-#      - '/usr/bin/env'
-#      - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-
-
-# before_script:
-#      - cd terraform
-#      - terraform --version
-#      - terraform init
-
-# stages:
-#       - plan
-#       - apply
-
-# plan:
-#    stage: plan
-#    script:
-#      - terraform plan -input=false -var-file="production.tfvars"
-
-# apply:
-#    stage: apply
-#    script:
-#      - terraform apply -input=false -auto-approve -var-file="production.tfvars"
-#    dependencies:
-#      - plan
-#    rules:
-#      - if: $CI_COMMIT_BRANCH == 'main'
+#image:
+#  name: hashicorp/terraform:light
+#  entrypoint:
+#    - '/usr/bin/env'
+#    - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+#
+#variables:
+#  DEVELOPMENT_STAGE: "dev"
+#  PRODUCTION_STAGE: "prd"
+#  STAGING_STAGE: "stg"
+#  DEVELOPMENT_BRANCH: "development"
+#  STAGING_BRANCH: "main"
+#
+#before_script:
+#  - cd terraform
+#  - terraform --version
+#  - terraform init
+#  - ./helpers/init_workspaces.sh
+#
+#stages:
+#  - validate
+#  - plan
+#  - apply
+#
+#.rules-development:
+#  rules:
+#    - if: $CI_COMMIT_BRANCH == $DEVELOPMENT_BRANCH
+#  variables:
+#    TERRAFORM_WORKSPACE: $DEVELOPMENT_STAGE
+#
+#
+#.rules-staging:
+#  rules:
+#    - if: $CI_COMMIT_BRANCH == $STAGING_BRANCH
+#  variables:
+#    TERRAFORM_WORKSPACE: $STAGING_STAGE
+#
+#.rules-production:
+#  rules:
+#    - if: $CI_COMMIT_TAG
+#  variables:
+#    TERRAFORM_WORKSPACE: $PRODUCTION_STAGE
+#
+#.validate:
+#  stage: validate
+#  script:
+#    - ./helpers/deploy.sh -a validate -s $TERRAFORM_WORKSPACE
+#
+#.plan:
+#  stage: plan
+#  script:
+#    - ./helpers/deploy.sh -a plan -s $TERRAFORM_WORKSPACE
+#
+#.apply:
+#  stage: apply
+#  script:
+#    - ./helpers/deploy.sh -a apply -s $TERRAFORM_WORKSPACE
+#
+#
+#validate-development:
+#  extends:
+#    - .validate
+#    - .rules-development
+#  dependencies:
+#    - plan-development
+#
+#validate-staging:
+#  extends:
+#    - .validate
+#    - .rules-staging
+#  dependencies:
+#    - plan-staging
+#
+#validate-production:
+#  extends:
+#    - .validate
+#    - .rules-production
+#  dependencies:
+#    - plan-production
+#
+#apply-development:
+#  extends:
+#    - .apply
+#    - .rules-development
+#  dependencies:
+#    - plan-development
+#
+#apply-staging:
+#  extends:
+#    - .apply
+#    - .rules-staging
+#  dependencies:
+#    - plan-staging
+#
+#apply-production:
+#  extends:
+#    - .apply
+#    - .rules-production
+#  dependencies:
+#    - plan-production

--- a/helpers/deploy.sh
+++ b/helpers/deploy.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Script options
+set -e # exit immediately if a command exits with a non-zero status
+
+# implement help option
+usage() { echo "Usage: $0 -a action -s <stage> [-y]" 1>&2; exit 1; }
+
+# Default values
+auto_approve_option=""
+
+# Parse options
+while getopts ":a:s:y" o; do
+    case "${o}" in
+        a)
+            action=${OPTARG}
+            ;;
+        s)
+            stage=${OPTARG}
+            ;;
+        y)
+            auto_approve_option="-auto-approve"
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+# Check if terraform is installed
+if ! command -v terraform &> /dev/null
+then
+    echo "Terraform could not be found."
+    exit 1
+fi
+
+# Check action argument
+if [ -z "${action}" ] || [ "${action}" != "plan" ] && [ "${action}" != "apply" ] && [ "${action}" != "validate" ]
+then
+    echo "Please provide either plan or apply as first argument."
+    exit 1
+fi
+
+# Check stage argument
+if [ -z "${stage}" ]
+then
+    echo "Please provide a stage as first argument."
+    # print available stages
+    echo "Available stages:"
+    terraform -chdir="terraform" workspace list
+    exit 1
+fi
+
+# Check if stage is valid with a terraform workspace
+terraform -chdir="terraform" workspace select "${stage}"
+if [ $? -ne 0 ]
+then
+    echo "Stage ${stage} is not a valid terraform workspace."
+    # print available stages
+    echo "Available stages:"
+    terraform -chdir="terraform" workspace list
+    exit 1
+fi
+
+# Check that variables file exists
+if [ ! -f "terraform/${stage}.tfvars" ]
+then
+    echo "Variables file terraform/${stage}.tfvars does not exist."
+    exit 1
+fi
+
+input_option=""
+if [ "${action}" == "apply" ] || [ "${action}" == "plan" ]
+then
+    input_option="-input=true"
+fi
+
+# perform terraform action
+terraform -chdir="terraform" "${action}" "$input_option" -var-file="${stage}.tfvars" ${auto_approve_option}
+

--- a/helpers/init_workspaces.sh
+++ b/helpers/init_workspaces.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Check if terraform is installed
+if ! command -v terraform &> /dev/null
+then
+  echo "Terraform could not be found."
+  exit 1
+fi
+
+# Create development workspace if it doesn't exist
+terraform -chdir="terraform" workspace new dev
+
+# Create staging workspace if it doesn't exist
+terraform -chdir="terraform" workspace new stg
+
+# Create production workspace if it doesn't exist
+terraform -chdir="terraform" workspace new prd
+
+# Change to development workspace
+terraform -chdir="terraform" workspace select dev

--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -1,0 +1,2 @@
+application_name = "test_terraform_stages"
+project          = "changeme"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,6 +19,8 @@ EOF
     ON_ERROR_CONTINUE="false"
     EXCLUDE_TEMP_IDS="false"
   }
+
+  stage = terraform.workspace
 }
 
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,21 +3,21 @@
 ###
 
 module "cgf_bigquery" {
-  source = "./modules/gf_gen2_bigquery_trigger_source_repo"
-  name = var.application_name
+  source      = "./modules/gf_gen2_bigquery_trigger_source_repo"
+  name        = var.application_name
   description = <<EOF
   This function will trigger when a bigquery table create or delete has happened
 EOF
-  project = var.project
+  project     = var.project
   entry_point = "main_bigquery_event"
   environment = {
-    PROJECT=var.project
-    GCS_PROJECT=var.project
-    GCS_BUCKET_NAME=var.bucket
-    INCLUDE_VARIABLES="false"
-    SHOW_ALL_ROWS="false"
-    ON_ERROR_CONTINUE="false"
-    EXCLUDE_TEMP_IDS="false"
+    PROJECT           = var.project
+    GCS_PROJECT       = var.project
+    GCS_BUCKET_NAME   = var.bucket
+    INCLUDE_VARIABLES = "false"
+    SHOW_ALL_ROWS     = "false"
+    ON_ERROR_CONTINUE = "false"
+    EXCLUDE_TEMP_IDS  = "false"
   }
 
   stage = terraform.workspace

--- a/terraform/modules/composer_environment/main.tf
+++ b/terraform/modules/composer_environment/main.tf
@@ -24,25 +24,25 @@ resource "google_project_iam_member" "composer-worker" {
 }
 
 resource "google_project_iam_member" "dataEditor" {
-  project = var.project
-  role     = "roles/bigquery.dataEditor"
-  member   = "serviceAccount:${google_service_account.account.email}"
+  project    = var.project
+  role       = "roles/bigquery.dataEditor"
+  member     = "serviceAccount:${google_service_account.account.email}"
   depends_on = [google_project_iam_member.composer-worker]
 }
 
 resource "google_project_iam_member" "jobUser" {
-  project = var.project
-  role     = "roles/bigquery.jobUser"
-  member   = "serviceAccount:${google_service_account.account.email}"
+  project    = var.project
+  role       = "roles/bigquery.jobUser"
+  member     = "serviceAccount:${google_service_account.account.email}"
   depends_on = [google_project_iam_member.dataEditor]
 }
 
 # Permissions for composer service account (google managed, so no need to create)
 resource "google_service_account_iam_member" "custom_service_account" {
-  provider = google-beta
+  provider           = google-beta
   service_account_id = google_service_account.account.id
-  role = "roles/composer.ServiceAgentV2Ext"
-  member = "serviceAccount:service-${data.google_project.project.number}@cloudcomposer-accounts.iam.gserviceaccount.com"
+  role               = "roles/composer.ServiceAgentV2Ext"
+  member             = "serviceAccount:service-${data.google_project.project.number}@cloudcomposer-accounts.iam.gserviceaccount.com"
 }
 
 resource "google_composer_environment" "test" {
@@ -69,7 +69,7 @@ resource "google_composer_environment" "test" {
         storage_gb = 1
       }
       worker {
-        cpu = var.worker_cpu
+        cpu        = var.worker_cpu
         memory_gb  = var.worker_memory_gb
         storage_gb = 1
         min_count  = var.min_workers

--- a/terraform/modules/composer_environment/main.tf
+++ b/terraform/modules/composer_environment/main.tf
@@ -13,7 +13,7 @@ resource "google_project_service" "composer" {
 }
 
 resource "google_service_account" "account" {
-  account_id   = "composer-env-account"
+  account_id   = "composer-${var.stage}-account"
   display_name = "Test Service Account for Composer Environment"
 }
 
@@ -46,8 +46,8 @@ resource "google_service_account_iam_member" "custom_service_account" {
 }
 
 resource "google_composer_environment" "test" {
-  name   = var.name
-  region = var.region
+  name    = "${var.name}-${var.stage}"
+  region  = var.region
   project = var.project
   config {
 

--- a/terraform/modules/composer_environment/variables.tf
+++ b/terraform/modules/composer_environment/variables.tf
@@ -81,3 +81,8 @@ variable "environment_size" {
   default     = "ENVIRONMENT_SIZE_SMALL"
 }
 
+variable "stage" {
+  description = "Stage of environment."
+  type        = string
+  default     = "dev"
+}

--- a/terraform/modules/composer_environment/variables.tf
+++ b/terraform/modules/composer_environment/variables.tf
@@ -1,83 +1,83 @@
 variable "name" {
   description = "Name of the composer environment."
-  type = string
+  type        = string
 }
 
 variable "project" {
-  description = "Project where environment is living"
-  type = string
+  description = "Project where environment is living."
+  type        = string
 
 }
 
 variable "region" {
-  description = "Region where environment is living"
-  type = string
-  default = "europe-west1"
+  description = "Region where environment is living."
+  type        = string
+  default     = "europe-west1"
 }
 
 variable "pypi_packages" {
-  description = "map of pypi packages"
-  type = map(string)
-  default= {
-        numpy = ""
-        pandas= ""
-        google-cloud-bigquery= ""
-        scipy=""
-      }
+  description = "Map of pypi packages."
+  type        = map(string)
+  default = {
+    numpy                 = ""
+    pandas                = ""
+    google-cloud-bigquery = ""
+    scipy                 = ""
+  }
 }
 
 variable "min_workers" {
-  description = "minimum amount of workers"
-  type = number
-  default = 1
+  description = "Minimum amount of workers."
+  type        = number
+  default     = 1
 }
 
 variable "max_workers" {
-  description = "maximum amount of workers"
-  type = number
-  default = 3
+  description = "Maximum amount of workers."
+  type        = number
+  default     = 3
 }
 
 
 variable "scheduler_cpu" {
-  description = "vCPU's appointed to the scheduler"
-  type = number
-  default = 0.5
+  description = "vCPU's appointed to the scheduler."
+  type        = number
+  default     = 0.5
 }
 
 variable "scheduler_memory_gb" {
-  description = "GB's of memory appointed to the scheduler"
-  type = number
-  default = 1.875
+  description = "GB's of memory appointed to the scheduler."
+  type        = number
+  default     = 1.875
 }
 
 variable "webserver_cpu" {
-  description = "vCPU's appointed to the scheduler"
-  type = number
-  default = 0.5
+  description = "vCPU's appointed to the scheduler."
+  type        = number
+  default     = 0.5
 }
 
 variable "webserver_memory_gb" {
-  description = "GB's of memory appointed to the scheduler"
-  type = number
-  default = 1.875
+  description = "GB's of memory appointed to the scheduler."
+  type        = number
+  default     = 1.875
 }
 
 variable "worker_cpu" {
-  description = "vCPU's appointed to the scheduler"
-  type = number
-  default = 0.5
+  description = "vCPU's appointed to the scheduler."
+  type        = number
+  default     = 0.5
 }
 
 variable "worker_memory_gb" {
-  description = "GB's of memory appointed to the scheduler"
-  type = number
-  default = 1.875
+  description = "GB's of memory appointed to the scheduler."
+  type        = number
+  default     = 1.875
 }
 
 variable "environment_size" {
-  description = "size of environment"
-  type = string
-  default = "ENVIRONMENT_SIZE_SMALL"
+  description = "Size of environment."
+  type        = string
+  default     = "ENVIRONMENT_SIZE_SMALL"
 }
 

--- a/terraform/modules/gcf_gen2_pubsub_source_repo/main.tf
+++ b/terraform/modules/gcf_gen2_pubsub_source_repo/main.tf
@@ -100,10 +100,9 @@ resource "google_cloudfunctions2_function" "function" {
     entry_point           = var.entry_point
     environment_variables = var.environment
     source {
-      repo_source {
-        project_id  = var.project
-        repo_name   = var.source_repo_name
-        branch_name = var.source_repo_branch
+      storage_source {
+        bucket = module.source_code.bucket_name
+        object = module.source_code.bucket_object_name
       }
     }
   }

--- a/terraform/modules/gcf_gen2_pubsub_source_repo/main.tf
+++ b/terraform/modules/gcf_gen2_pubsub_source_repo/main.tf
@@ -129,7 +129,7 @@ resource "google_cloudfunctions2_function" "function" {
   depends_on = [
     google_project_service.cloud_build_api,
     google_project_service.cloud_functions_api,
-    google_project_service.pubsub_api,
-    google_project_service.artifactregistry_api,
+    google_pubsub_topic.topic,
+    google_project_service.artifact_registry_api
   ]
 }

--- a/terraform/modules/gcf_gen2_pubsub_source_repo/main.tf
+++ b/terraform/modules/gcf_gen2_pubsub_source_repo/main.tf
@@ -34,6 +34,18 @@ resource "google_project_service" "pubsub_api" {
   disable_on_destroy = false
 }
 
+resource "google_project_service" "scheduler_api" {
+  project            = var.project
+  service            = "cloudscheduler.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "artifact_registry_api" {
+  project            = var.project
+  service            = "artifactregistry.googleapis.com"
+  disable_on_destroy = false
+}
+
 resource "google_pubsub_topic" "topic" {
   name = "${var.name}_${var.stage}_trigger_topic"
 
@@ -88,7 +100,17 @@ resource "google_project_iam_member" "token_creator_access_ce" {
   member  = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
 }
 
+resource "google_project_iam_member" "run_invoker_access" {
+  project = var.project
+  role    = "roles/run.invoker"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
 
+resource "google_project_iam_member" "run_invoker_access_ce" {
+  project = var.project
+  role    = "roles/run.invoker"
+  member  = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+}
 
 resource "google_cloudfunctions2_function" "function" {
   name        = "${var.name}_${var.stage}_function"

--- a/terraform/modules/gcf_gen2_pubsub_source_repo/variables.tf
+++ b/terraform/modules/gcf_gen2_pubsub_source_repo/variables.tf
@@ -9,14 +9,19 @@ variable "description" {
 }
 
 variable "region" {
-  description = "Region where function is living"
+  description = "Region where function is living."
+  default     = "europe-west1"
+}
+
+variable "function_region" {
+  description = "Region where function is living."
   default     = "europe-west1"
 }
 
 variable "runtime" {
   description = "Runtime where function is operating."
   type        = string
-  default     = "python39"
+  default     = "python310"
 }
 
 variable "source_repo_name" {
@@ -41,15 +46,8 @@ variable "available_memory" {
   default     = "2G"
 }
 
-
-variable "available_cpu" {
-  description = "The amount of vCPUs available for a function. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions2_function"
-  type        = string
-  default     = "1"
-}
-
 variable "max_instances" {
-  description = "Amount of instances of this function allowed to run simultaneously"
+  description = "Amount of instances of this function allowed to run simultaneously."
   type        = number
   default     = 10
 }

--- a/terraform/modules/gcf_gen2_pubsub_source_repo/variables.tf
+++ b/terraform/modules/gcf_gen2_pubsub_source_repo/variables.tf
@@ -76,3 +76,8 @@ variable "schedule" {
   default     = "*/2 * * * *"
 
 }
+
+variable "stage" {
+  description = "Stage of deployment."
+  type        = string
+}

--- a/terraform/modules/gcs_folder_sync/main.tf
+++ b/terraform/modules/gcs_folder_sync/main.tf
@@ -1,12 +1,12 @@
 resource "google_storage_bucket" "bucket" {
-  name     = var.bucket
-  location = "EU"
+  name     = "${var.bucket}-${var.stage}"
+  location = var.region
 }
 
 resource "google_storage_bucket_object" "map" {
-  for_each = fileset("${path.root}/${var.gcs_local_source_path}", "**")
-  name   = "${var.gcs_bucket_file_path}${each.value}"
-  source = "${path.root}/${var.gcs_local_source_path}/${each.value}"
-  bucket = var.bucket
+  for_each   = fileset("${path.root}/${var.gcs_local_source_path}", "**")
+  name       = "${var.gcs_bucket_file_path}${each.value}"
+  source     = "${path.root}/${var.gcs_local_source_path}/${each.value}"
+  bucket     = google_storage_bucket.bucket.name
   depends_on = [google_storage_bucket.bucket]
 }

--- a/terraform/modules/gcs_folder_sync/variables.tf
+++ b/terraform/modules/gcs_folder_sync/variables.tf
@@ -15,3 +15,13 @@ variable "gcs_bucket_file_path" {
   type        = string
   default     = "dags/"
 }
+
+variable "region" {
+  description = "Region where function is living."
+  default     = "europe-west1"
+}
+
+variable "stage" {
+  description = "The stage of the pipeline, either 'dev', 'prd' or 'stg'."
+  type        = string
+}

--- a/terraform/modules/gcs_folder_sync/variables.tf
+++ b/terraform/modules/gcs_folder_sync/variables.tf
@@ -1,17 +1,17 @@
 variable "bucket" {
-  description = "bucket name."
-  type = string
+  description = "Bucket name. It will be appended with the stage name."
+  type        = string
 }
 
 
 variable "gcs_local_source_path" {
   description = "The local path (without opening / ending slash) to the directory that needs to be synced, relative to the terraform/main.tf file location"
-  type = string
-  default="../project_name/dags_folder"
+  type        = string
+  default     = "../project_name/dags_folder"
 }
 
 variable "gcs_bucket_file_path" {
   description = "The path (with ending slash) to the directory that files need to be synced to in the gcs_bucket, provide empty string if not relevant"
-  type = string
-  default="dags/"
+  type        = string
+  default     = "dags/"
 }

--- a/terraform/modules/gcs_source/main.tf
+++ b/terraform/modules/gcs_source/main.tf
@@ -1,0 +1,30 @@
+## Create and upload source zip to special created functions bucket
+
+locals {
+  timestamp = formatdate("YYMMDDhhmmss", timestamp())
+}
+
+data "archive_file" "source" {
+  type        = "zip"
+  source_dir  = "${path.root}/.."
+  output_path = "/tmp/git-function-${local.timestamp}.zip"
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "${var.project}-${var.stage}-${var.app_name}-source"
+  location = var.region
+}
+
+resource "google_storage_bucket_object" "archive" {
+  name   = "source.zip#${data.archive_file.source.output_md5}"
+  bucket = google_storage_bucket.bucket.name
+  source = data.archive_file.source.output_path
+}
+
+output "bucket_name" {
+  value = google_storage_bucket.bucket.name
+}
+
+output "bucket_object_name" {
+  value = google_storage_bucket_object.archive.name
+}

--- a/terraform/modules/gcs_source/variables.tf
+++ b/terraform/modules/gcs_source/variables.tf
@@ -1,0 +1,19 @@
+variable "region" {
+  description = "Region where function is living."
+  default     = "europe-west1"
+}
+
+variable "app_name" {
+  description = "Name of the function."
+  type        = string
+}
+
+variable "project" {
+  description = "Project ID."
+  type        = string
+}
+
+variable "stage" {
+  description = "Stage of deployment."
+  type        = string
+}

--- a/terraform/modules/gf_gen1_bucket_trigger_source_repo/main.tf
+++ b/terraform/modules/gf_gen1_bucket_trigger_source_repo/main.tf
@@ -10,18 +10,24 @@ resource "google_project_service" "cloud_functions_api" {
   disable_on_destroy = false
 }
 
+module "source_code" {
+  source   = "../gcs_source"
+  project  = var.project
+  stage    = var.stage
+  app_name = var.name
+}
+
 resource "google_cloudfunctions_function" "gcs_triggered_function" {
-  name = var.name
-  description = var.description
-  region = var.region
-  runtime = var.runtime
-  entry_point = var.entry_point
-  source_repository {
-    url = "https://source.developers.google.com/projects/${var.project}/repos/${var.source_repo_name}/moveable-aliases/main"
-  }
-  available_memory_mb = var.available_memory_mb
-  timeout = var.timeout
-  max_instances = var.max_instances
+  name                  = "${var.name}-${var.stage}"
+  description           = var.description
+  region                = var.region
+  runtime               = var.runtime
+  entry_point           = var.entry_point
+  source_archive_bucket = module.source_code.bucket_name
+  source_archive_object = module.source_code.object_name
+  available_memory_mb   = var.available_memory_mb
+  timeout               = var.timeout
+  max_instances         = var.max_instances
   # This should be done in another way, it seems clunky
   environment_variables = var.environment
   event_trigger {

--- a/terraform/modules/gf_gen1_bucket_trigger_source_repo/main.tf
+++ b/terraform/modules/gf_gen1_bucket_trigger_source_repo/main.tf
@@ -25,8 +25,8 @@ resource "google_cloudfunctions_function" "gcs_triggered_function" {
   # This should be done in another way, it seems clunky
   environment_variables = var.environment
   event_trigger {
-        event_type = var.trigger_event_type
-        resource = var.trigger_resource
+    event_type = var.trigger_event_type
+    resource   = var.trigger_resource
   }
 
   depends_on = [google_project_service.cloud_build_api, google_project_service.cloud_functions_api]

--- a/terraform/modules/gf_gen1_bucket_trigger_source_repo/variables.tf
+++ b/terraform/modules/gf_gen1_bucket_trigger_source_repo/variables.tf
@@ -69,3 +69,8 @@ variable "timeout" {
   type        = number
   default     = 540
 }
+
+variable "stage" {
+  description = "Stage of the Cloud Function. Can be dev, stg or prd."
+  type        = string
+}

--- a/terraform/modules/gf_gen1_bucket_trigger_source_repo/variables.tf
+++ b/terraform/modules/gf_gen1_bucket_trigger_source_repo/variables.tf
@@ -1,71 +1,71 @@
 variable "name" {
   description = "Name of the function."
-  type = string
+  type        = string
 }
 
 variable "description" {
   description = "Description of the function."
-  type = string
+  type        = string
 }
 
 variable "region" {
   description = "Region where function is living"
-  default = "europe-west1"
+  default     = "europe-west1"
 }
 
 variable "runtime" {
   description = "Runtime where function is operating."
-  type = string
-  default = "python39"
+  type        = string
+  default     = "python310"
 }
 
 variable "source_repo_name" {
   description = "Name of the Cloud Repository that hosts the function definition."
-  type = string
+  type        = string
 }
 
 variable "project" {
   description = "Project ID."
-  type = string
+  type        = string
 }
 
 variable "available_memory_mb" {
   description = "Amount of memory available in MB."
-  type = number
-  default = 2048
+  type        = number
+  default     = 2048
 }
 
 variable "max_instances" {
   description = "Amount of instances of this function allowed to run simultaneously"
-  type = number
-  default = 10
+  type        = number
+  default     = 10
 }
 
 variable "environment" {
   description = "Environment variables to be forwarded to function."
-  type = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
 }
 
 variable "trigger_resource" {
   description = "Name of resource that is supposed to trigger function"
-  type = string
+  type        = string
 }
 
 variable "trigger_event_type" {
   description = "Type of event type the function should trigger on."
-  type = string
-  default = "google.storage.object.finalize"
+  type        = string
+  default     = "google.storage.object.finalize"
 }
 
 variable "entry_point" {
   description = "Entry point method of the Cloud function."
-  type = string
-  default = "main_cloud_event"
+  type        = string
+  default     = "main_cloud_event"
 }
 
 variable "timeout" {
   description = "Timeout of the Cloud Function."
-  type = number
-  default = 540
+  type        = number
+  default     = 540
 }

--- a/terraform/modules/gf_gen1_http_trigger_source_repo/main.tf
+++ b/terraform/modules/gf_gen1_http_trigger_source_repo/main.tf
@@ -10,18 +10,24 @@ resource "google_project_service" "cloud_functions_api" {
   disable_on_destroy = false
 }
 
+module "source_code" {
+  source   = "../gcs_source"
+  project  = var.project
+  stage    = var.stage
+  app_name = var.name
+}
+
 resource "google_cloudfunctions_function" "gcs_triggered_function" {
-  name = var.name
-  description = var.description
-  region = var.region
-  runtime = var.runtime
-  entry_point = var.entry_point
-  source_repository {
-    url = "https://source.developers.google.com/projects/${var.project}/repos/${var.source_repo_name}/moveable-aliases/main"
-  }
-  available_memory_mb = var.available_memory_mb
-  timeout = var.timeout
-  max_instances = var.max_instances
+  name                  = "${var.name}-${var.stage}"
+  description           = var.description
+  region                = var.region
+  runtime               = var.runtime
+  entry_point           = var.entry_point
+  source_archive_bucket = module.source_code.bucket_name
+  source_archive_object = module.source_code.object_name
+  available_memory_mb   = var.available_memory_mb
+  timeout               = var.timeout
+  max_instances         = var.max_instances
   # This should be done in another way, it seems clunky
   environment_variables = var.environment
   trigger_http          = true

--- a/terraform/modules/gf_gen1_http_trigger_source_repo/main.tf
+++ b/terraform/modules/gf_gen1_http_trigger_source_repo/main.tf
@@ -24,7 +24,7 @@ resource "google_cloudfunctions_function" "gcs_triggered_function" {
   max_instances = var.max_instances
   # This should be done in another way, it seems clunky
   environment_variables = var.environment
-  trigger_http = true
+  trigger_http          = true
 
   depends_on = [google_project_service.cloud_build_api, google_project_service.cloud_functions_api]
 }

--- a/terraform/modules/gf_gen1_http_trigger_source_repo/variables.tf
+++ b/terraform/modules/gf_gen1_http_trigger_source_repo/variables.tf
@@ -1,60 +1,60 @@
 variable "name" {
   description = "Name of the function."
-  type = string
+  type        = string
 }
 
 variable "description" {
   description = "Description of the function."
-  type = string
+  type        = string
 }
 
 variable "region" {
   description = "Region where function is living"
-  default = "europe-west1"
+  default     = "europe-west1"
 }
 
 variable "runtime" {
   description = "Runtime where function is operating."
-  type = string
-  default = "python39"
+  type        = string
+  default     = "python310"
 }
 
 variable "source_repo_name" {
   description = "Name of the Cloud Repository that hosts the function definition."
-  type = string
+  type        = string
 }
 
 variable "project" {
   description = "Project ID."
-  type = string
+  type        = string
 }
 
 variable "available_memory_mb" {
   description = "Amount of memory available in MB."
-  type = number
-  default = 2048
+  type        = number
+  default     = 2048
 }
 
 variable "max_instances" {
   description = "Amount of instances of this function allowed to run simultaneously"
-  type = number
-  default = 10
+  type        = number
+  default     = 10
 }
 
 variable "environment" {
   description = "Environment variables to be forwarded to function."
-  type = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
 }
 
 variable "entry_point" {
   description = "Entry point method of the Cloud function."
-  type = string
-  default = "main_cloud_event"
+  type        = string
+  default     = "main_cloud_event"
 }
 
 variable "timeout" {
   description = "Timeout of the Cloud Function."
-  type = number
-  default = 540
+  type        = number
+  default     = 540
 }

--- a/terraform/modules/gf_gen1_http_trigger_source_repo/variables.tf
+++ b/terraform/modules/gf_gen1_http_trigger_source_repo/variables.tf
@@ -58,3 +58,8 @@ variable "timeout" {
   type        = number
   default     = 540
 }
+
+variable "stage" {
+  description = "Stage of the Cloud Function. Can be dev, stg or prd."
+  type        = string
+}

--- a/terraform/modules/gf_gen2_bigquery_trigger_source_repo/main.tf
+++ b/terraform/modules/gf_gen2_bigquery_trigger_source_repo/main.tf
@@ -45,7 +45,7 @@ resource "google_project_iam_member" "token-creating" {
 
 ## Own service account that creates and runs the cloud function
 resource "google_service_account" "account" {
-  account_id   = "gcf-exec-automations"
+  account_id   = "gcf-exec-automations-${var.stage}"
   display_name = "Test Service Account - used for both the cloud function and eventarc trigger in the test"
 }
 
@@ -118,7 +118,7 @@ resource "google_storage_bucket_object" "archive" {
 ## Actual declaration of the cloud function
 
 resource "google_cloudfunctions2_function" "function" {
-  name        = var.name
+  name        = "${var.name}-${var.stage}"
   location    = var.region
   description = var.description
 

--- a/terraform/modules/gf_gen2_bigquery_trigger_source_repo/variables.tf
+++ b/terraform/modules/gf_gen2_bigquery_trigger_source_repo/variables.tf
@@ -1,70 +1,59 @@
 variable "name" {
   description = "Name of the function."
-  type = string
+  type        = string
 }
 
 variable "description" {
   description = "Description of the pub/sub function."
-  type = string
+  type        = string
 }
 
 variable "project" {
   description = "Project ID."
-  type = string
+  type        = string
 }
 
 variable "region" {
   description = "Region where function is living"
-  default = "europe-west4"
+  default     = "EU"
 }
 
 variable "runtime" {
   description = "Runtime where function is operating."
-  type = string
-  default = "python39"
+  type        = string
+  default     = "python310"
 }
-
-# variable "source_repo_name" {
-#   description = "Name of the Cloud Repository that hosts the function definition."
-#   type = string
-# }
-
-# variable "source_repo_branch" {
-#   description = "Branch name containing code to be deployed."
-#   type = string
-#   default = "main"
-# }
 
 variable "available_memory" {
   description = "The amount of memory available for a function. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions2_function"
-  type = string
-  default = "2G"
+  type        = string
+  default     = "2G"
 }
 
 variable "max_instances" {
   description = "Amount of instances of this function allowed to run simultaneously"
-  type = number
-  default = 10
+  type        = number
+  default     = 10
 }
 
 variable "environment" {
   description = "Environment variables to be forwarded to function."
-  type = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
 }
 
 
 
 variable "entry_point" {
   description = "Entry point method of the Cloud function."
-  type = string
-  default = "main_pubsub"
+  type        = string
+  default     = "main_pubsub"
 }
 
 variable "timeout" {
   description = "Timeout of the Cloud Function."
-  type = number
-  default = 540
+  type        = number
+  default     = 540
 }
 
 variable "topic" {
@@ -72,11 +61,3 @@ variable "topic" {
   type = string
   default = "gcf_periodic_trigger"
 }
-
-variable "schedule" {
-  description = "The schedule on which to trigger the function."
-  type = string
-  default = "*/2 * * * *"
-
-}
-

--- a/terraform/modules/gf_gen2_bigquery_trigger_source_repo/variables.tf
+++ b/terraform/modules/gf_gen2_bigquery_trigger_source_repo/variables.tf
@@ -56,8 +56,7 @@ variable "timeout" {
   default     = 540
 }
 
-variable "topic" {
-  description = "Name of Pub/Sub topic to create as trigger"
-  type = string
-  default = "gcf_periodic_trigger"
+variable "stage" {
+  description = "Stage of the function. Can be dev, stg or prd."
+  type        = string
 }

--- a/terraform/modules/main_triggers/main_bq_trigger_gcf.tf
+++ b/terraform/modules/main_triggers/main_bq_trigger_gcf.tf
@@ -1,25 +1,27 @@
 module "cgf_bigquery" {
-  source = "./modules/gf_gen2_bigquery_trigger_source_repo"
-  name = var.application_name
+  source      = "./modules/gf_gen2_bigquery_trigger_source_repo"
+  name        = var.application_name
   description = <<EOF
   This function will trigger when a bigquery table create or delete has happened
 EOF
-  project = var.project
+  project     = var.project
   entry_point = "main_bigquery_event"
   environment = {
-    PROJECT=var.project
-    GCS_PROJECT=var.project
-    GCS_BUCKET_NAME=var.bucket
-    INCLUDE_VARIABLES="false"
-    SHOW_ALL_ROWS="false"
-    ON_ERROR_CONTINUE="false"
-    EXCLUDE_TEMP_IDS="false"
+    PROJECT           = var.project
+    GCS_PROJECT       = var.project
+    GCS_BUCKET_NAME   = var.bucket
+    INCLUDE_VARIABLES = "false"
+    SHOW_ALL_ROWS     = "false"
+    ON_ERROR_CONTINUE = "false"
+    EXCLUDE_TEMP_IDS  = "false"
   }
+  stage = terraform.workspace
 }
 
-module  "gcs_sync" {
-  source = "./modules/gcs_folder_sync"
-  bucket = var.bucket
-  gcs_bucket_file_path = ""
+module "gcs_sync" {
+  source                = "./modules/gcs_folder_sync"
+  bucket                = var.bucket
+  gcs_bucket_file_path  = ""
   gcs_local_source_path = "../project_name/SQL/sql_scripts"
+  stage                 = terraform.workspace
 }

--- a/terraform/modules/main_triggers/main_bucket_trigger_gcf.tf
+++ b/terraform/modules/main_triggers/main_bucket_trigger_gcf.tf
@@ -9,16 +9,16 @@ resource "google_storage_bucket" "landing_bucket" {
 
 
 module "cf_gcs_to_bq" {
-  source = "./modules/gf_gen1_bucket_trigger_source_repo"
-  name = var.application_name
-  description = <<EOF
+  source           = "./modules/gf_gen1_bucket_trigger_source_repo"
+  name             = var.application_name
+  description      = <<EOF
 This function will trigger on new files saved in the trigger bucket
 and process the data, finally inserting it into a BQ dataset
 EOF
   source_repo_name = var.source_repo_name
-  project = var.project
+  project          = var.project
   trigger_resource = google_storage_bucket.landing_bucket.name
-  entry_point = "main_gcs_event"
+  entry_point      = "main_gcs_event"
   environment = {
     TARGET_BQ_TABLE = "${google_bigquery_table.target_table.project}.${google_bigquery_table.target_table.dataset_id}.${google_bigquery_table.target_table.table_id}"
   }

--- a/terraform/modules/main_triggers/main_bucket_trigger_gcf.tf
+++ b/terraform/modules/main_triggers/main_bucket_trigger_gcf.tf
@@ -1,5 +1,5 @@
 resource "google_storage_bucket" "landing_bucket" {
-  name          = "${var.project}-my-processing-bucket-${var.region}"
+  name          = "${var.project}-my-processing-bucket-${var.region}-${terraform.workspace}"
   location      = var.region
   storage_class = "STANDARD"
   versioning {
@@ -22,4 +22,6 @@ EOF
   environment = {
     TARGET_BQ_TABLE = "${google_bigquery_table.target_table.project}.${google_bigquery_table.target_table.dataset_id}.${google_bigquery_table.target_table.table_id}"
   }
+
+  stage = terraform.workspace
 }

--- a/terraform/modules/main_triggers/main_composer_environment.tf
+++ b/terraform/modules/main_triggers/main_composer_environment.tf
@@ -5,8 +5,8 @@
 #   bucket = var.bucket
 # }
 
-module  "composer_environment" {
-  source = "./modules/composer_environment"
-  name = "fillinyourname"
+module "composer_environment" {
+  source  = "./modules/composer_environment"
+  name    = "fillinyourname"
   project = var.project
 }

--- a/terraform/modules/main_triggers/main_composer_environment.tf
+++ b/terraform/modules/main_triggers/main_composer_environment.tf
@@ -9,4 +9,5 @@ module "composer_environment" {
   source  = "./modules/composer_environment"
   name    = "fillinyourname"
   project = var.project
+  stage   = terraform.workspace
 }

--- a/terraform/modules/main_triggers/main_http_trigger_gcf.tf
+++ b/terraform/modules/main_triggers/main_http_trigger_gcf.tf
@@ -12,4 +12,6 @@ EOF
     ORDERS_FOLDER   = google_storage_bucket_object.orders_folder.name
     ORDERS_BQ_TABLE = "${google_bigquery_table.orders_table.project}.${google_bigquery_table.orders_table.dataset_id}.${google_bigquery_table.orders_table.table_id}"
   }
+
+  stage = terraform.workspace
 }

--- a/terraform/modules/main_triggers/main_http_trigger_gcf.tf
+++ b/terraform/modules/main_triggers/main_http_trigger_gcf.tf
@@ -1,15 +1,15 @@
 module "cf_http_trigger_bq_processing" {
-  source = "./modules/gf_gen1_http_trigger_source_repo"
-  name = var.application_name
-  description = <<EOF
+  source           = "./modules/gf_gen1_http_trigger_source_repo"
+  name             = var.application_name
+  description      = <<EOF
 This function will trigger on new files saved in the trigger bucket
 and process the data, finally inserting it into a BQ dataset
 EOF
   source_repo_name = var.source_repo_name
-  project = var.project
-  entry_point = "main_http_event"
+  project          = var.project
+  entry_point      = "main_http_event"
   environment = {
-    ORDERS_FOLDER = google_storage_bucket_object.orders_folder.name
+    ORDERS_FOLDER   = google_storage_bucket_object.orders_folder.name
     ORDERS_BQ_TABLE = "${google_bigquery_table.orders_table.project}.${google_bigquery_table.orders_table.dataset_id}.${google_bigquery_table.orders_table.table_id}"
   }
 }

--- a/terraform/modules/main_triggers/main_scheduled_trigger_gcf.tf
+++ b/terraform/modules/main_triggers/main_scheduled_trigger_gcf.tf
@@ -13,4 +13,6 @@ EOF
     ORDERS_BQ_TABLE = "${google_bigquery_table.orders_table.project}.${google_bigquery_table.orders_table.dataset_id}.${google_bigquery_table.orders_table.table_id}"
   }
   schedule = "*/2 * * * *"
+
+  stage = terraform.workspace
 }

--- a/terraform/modules/main_triggers/main_scheduled_trigger_gcf.tf
+++ b/terraform/modules/main_triggers/main_scheduled_trigger_gcf.tf
@@ -1,15 +1,15 @@
 module "cgf_pubsub" {
-  source = "./modules/gcf_gen2_pubsub_source_repo"
-  name = var.application_name
-  description = <<EOF
+  source             = "./modules/gcf_gen2_pubsub_source_repo"
+  name               = var.application_name
+  description        = <<EOF
   This function will trigger when a new pubsub message is published.
 EOF
-  source_repo_name = var.source_repo_name
+  source_repo_name   = var.source_repo_name
   source_repo_branch = var.source_repo_branch
-  project = var.project
-  entry_point = "main_pubsub"
+  project            = var.project
+  entry_point        = "main_pubsub"
   environment = {
-    ORDERS_FOLDER = google_storage_bucket_object.orders_folder.name
+    ORDERS_FOLDER   = google_storage_bucket_object.orders_folder.name
     ORDERS_BQ_TABLE = "${google_bigquery_table.orders_table.project}.${google_bigquery_table.orders_table.dataset_id}.${google_bigquery_table.orders_table.table_id}"
   }
   schedule = "*/2 * * * *"

--- a/terraform/prd.tfvars
+++ b/terraform/prd.tfvars
@@ -1,0 +1,2 @@
+application_name = "test_terraform_stages"
+project          = "changeme"

--- a/terraform/production.tfvars
+++ b/terraform/production.tfvars
@@ -1,3 +1,0 @@
-application_name = "<changethisname>"
-project="<changethisvalue>"
-bucket="<changethisvalue>"

--- a/terraform/remote-state/main.tf
+++ b/terraform/remote-state/main.tf
@@ -1,6 +1,6 @@
 resource "google_storage_bucket" "tfstate" {
   name          = "project_name-${var.project}-tfstate"
-  project = var.project
+  project       = var.project
   force_destroy = false
   location      = "EU"
   storage_class = "STANDARD"

--- a/terraform/remote-state/variables.tf
+++ b/terraform/remote-state/variables.tf
@@ -1,5 +1,5 @@
 variable "project" {
   description = "Project ID"
-  type = string
-  default = "emerald-eon-368712"
+  type        = string
+  default     = "<changeme>"
 }

--- a/terraform/stg.tfvars
+++ b/terraform/stg.tfvars
@@ -1,0 +1,2 @@
+application_name = "test_terraform_stages"
+project          = "changeme"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -31,12 +31,12 @@ variable "source_repo_name" {
 
 variable "source_repo_branch" {
   description = "Branch name containing code to be deployed."
-  type = string
-  default = "main"
+  type        = string
+  default     = "main"
 }
 
 variable "bucket" {
   description = "bucket name."
-  type = string
-  default=""
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
### Summary :memo:
This PR implements staged deployments of terraform configurations and their binding with branches/tags in CI/CD.

Additionally, it changes all modules that deploy a Cloud Function to get their source code from GCS.

This PR is best reviewed commit by commit

### Details
**Regarding staged deployments in Terraform configuration**
1. Change resources names inside modules to include the stage that we are deploying to
2. Add top level variable in each module to ingest the `stage`
3. Set `stage = terraform.workspace` in the examples

**Regarding staged deployments in CD/CD configuration**
1. Build helper scripts for terraform to facilitate switching of workspaces and deploying
2. Add jobs to `.github/workflows/terraform.yml` such that
    * `development` branch gets deployed to the `dev` environment
    * `main` branch gets deployed to `stg` environment
    * tags get deployed to `prd` environment

**Regarding packaging of code and sourcing from GCS**
1. Modularized previous contribution in #11 regarding GCS deployment of code into a `terraform/modules/gcs_source`
2. Changed all modules that deploy a Cloud Function to use that deployment method

### Bugfixes :bug:
- Fixes issue with Pub/Sub invocation of Cloud Functions Gen 2

### Checks
- [ ] Should close [Create standardized Test / Prod environments](https://app.asana.com/0/1203625470344655/1204328182659373)
- [x] Tested Changes (see https://github.com/cloudninedigital/test-etl-template-stages/actions) for GitHub
- [ ] Tested changes for Gitlab


### Budget
Time spent on this PR review should be allocated in the following Harvest project: [CND42].
