### PR TITLE
[terraform] Add dependency on pubsub API creation

### DIFF
--- a/terraform/modules/gcf_gen2_pubsub_source_repo/main.tf
+++ b/terraform/modules/gcf_gen2_pubsub_source_repo/main.tf
@@ -91,6 +91,8 @@ resource "google_project_iam_member" "token_creator_access" {
   project = var.project
   role    = "roles/iam.serviceAccountTokenCreator"
   member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+
+  depends_on = [google_project_service.pubsub_api]
 }
 
 resource "google_project_iam_member" "token_creator_access_ce" {
@@ -103,6 +105,8 @@ resource "google_project_iam_member" "run_invoker_access" {
   project = var.project
   role    = "roles/run.invoker"
   member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+
+  depends_on = [google_project_service.pubsub_api]
 }
 
 resource "google_project_iam_member" "run_invoker_access_ce" {

--- a/terraform/modules/gf_gen2_bigquery_trigger_source_repo/main.tf
+++ b/terraform/modules/gf_gen2_bigquery_trigger_source_repo/main.tf
@@ -35,12 +35,20 @@ resource "google_project_service" "eventarc" {
   disable_on_destroy = false
 }
 
+resource "google_project_service" "pubsub" {
+  project = var.project
+  service            = "pubsub.googleapis.com"
+  disable_on_destroy = false
+}
+
 ##  Permissions for pubsub service account to handle event-arc events (google managed, so no need to create)
 
 resource "google_project_iam_member" "token-creating" {
   project = var.project
   role    = "roles/iam.serviceAccountTokenCreator"
   member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+
+  depends_on = [google_project_service.pubsub]
 }
 
 


### PR DESCRIPTION
### Summary :memo:
Fixes the error that the pubsub service account does not exist by the time iam binding needs to be applied.

### Details
_Describe more what you did on changes._
1. Add dependencies on the pubsub service in iam_binding for the pubsub service accoun



### Budget
Time spent on this PR review should be allocated in the following Harvest project: [CND42].