### PR TITLE
Feature alert policy bq executor

### DIFF
--- a/terraform/modules/alert_policy/variables.tf
+++ b/terraform/modules/alert_policy/variables.tf
@@ -16,6 +16,7 @@ variable "filter" {
 variable "label_extractors" {
     description = "label extractors"
     type = map(string)
+    default = {}
 }
 
 variable "notification_rate_limit" {

--- a/terraform/modules/alert_policy/variables.tf
+++ b/terraform/modules/alert_policy/variables.tf
@@ -3,6 +3,31 @@ variable "name" {
   type = string
 }
 
+variable "documentation" {
+  description = "Notification text in alert."
+  type = string
+  default = ""
+}
+
 variable "filter" {
   description = "filter condition on logs"
+}
+
+variable "label_extractors" {
+    description = "label extractors"
+    type = map(string)
+}
+
+variable "notification_rate_limit" {
+    description = "notification rate limit"
+    type = string
+    default = "300s"
+}
+
+variable "email_addresses" {
+    description = "email addresses to send notifications to"
+    type = map(string)
+    default = {
+      cnd_alerts = "alerting@cloudninedigital.nl"
+    }
 }

--- a/terraform/modules/bq_executor_alert_policy/main.tf
+++ b/terraform/modules/bq_executor_alert_policy/main.tf
@@ -1,0 +1,10 @@
+module "bq_executor_alerting_policy" {
+  source = "../alert_policy"
+  name = var.name
+  filter = var.filter
+
+  documentation = var.documentation
+
+  email_addresses = var.email_addresses
+  label_extractors = var.label_extractors
+}

--- a/terraform/modules/bq_executor_alert_policy/variables.tf
+++ b/terraform/modules/bq_executor_alert_policy/variables.tf
@@ -1,0 +1,56 @@
+variable "name" {
+  description = "name of alert policy"
+  type = string
+}
+
+variable "documentation" {
+  description = "Notification text in alert."
+  type = string
+  default = <<EOT
+# bq-executor job failed
+This policy is to alert when bq-executor job fails.
+
+## Failed query
+
+$${log.extracted_labels.query}
+
+## Error message
+
+$${log.extracted_labels.error}
+EOT
+}
+
+variable "filter" {
+  description = "filter condition on logs"
+  type = string
+  default = <<EOT
+protoPayload.methodName="google.cloud.bigquery.v2.JobService.InsertJob"
+severity=ERROR
+protoPayload.metadata.jobChange.job.jobStatus.jobState="DONE"
+protoPayload.metadata.jobChange.job.jobName:"bq-executor"
+resource.type="bigquery_project"
+  EOT
+}
+
+variable "label_extractors" {
+    description = "label extractors"
+    type = map(string)
+    default = {
+    query = "EXTRACT(protoPayload.metadata.jobChange.job.jobConfig.queryConfig.query)"
+    error = "EXTRACT(protoPayload.metadata.jobChange.job.jobStatus.errorResult.message)"
+  }
+}
+
+variable "notification_rate_limit" {
+    description = "notification rate limit"
+    type = string
+    default = "300s"
+}
+
+variable "email_addresses" {
+  description = "email addresses to send notifications to"
+  type = map(string)
+  default = {
+    siteanalyse = "siteanalyse@anwb.nl"
+  }
+}

--- a/terraform/modules/bq_executor_alert_policy/variables.tf
+++ b/terraform/modules/bq_executor_alert_policy/variables.tf
@@ -51,6 +51,6 @@ variable "email_addresses" {
   description = "email addresses to send notifications to"
   type = map(string)
   default = {
-    siteanalyse = "siteanalyse@anwb.nl"
+    cnd_alerts = "alerting@cloudninedigital.nl"
   }
 }

--- a/terraform/modules/workflows_cf/main.tf
+++ b/terraform/modules/workflows_cf/main.tf
@@ -150,13 +150,6 @@ resource "google_workflows_workflow" "workflows_instance" {
   ]
 }
 
-## alerting policy
-module "alerting_policy" {
-  source = "../alert_policy"
-  count = var.alert_on_failure ? 1 : 0
-  name = "${var.name}-alert-policy"
-  filter = "resource.type=\"workflows.googleapis.com/Workflow\" severity=ERROR resource.labels.workflow_id=\"${var.name}\""
-}
 
 
 ### START bq TRIGGER SPECIFIC PART
@@ -279,4 +272,18 @@ resource "google_cloud_scheduler_job" "workflow" {
   google_project_iam_member.cloudscheduler_admin_binding ]
 }
 
+
+module "bq_executor_alerting_policy" {
+  source = "../bq_executor_alert_policy"
+  count = ((var.trigger_type == "bq") && var.alert_on_failure) ? 1 : 0
+  name = "${var.name}_bq_executor_alert"
+}
+
+## alerting policy
+module "alerting_policy" {
+  source = "../alert_policy"
+  count = ((var.trigger_type != "bq") && var.alert_on_failure) ? 1 : 0
+  name = "${var.name}-alert-policy"
+  filter = "resource.type=\"workflows.googleapis.com/Workflow\" severity=ERROR resource.labels.workflow_id=\"${var.name}\""
+}
 ### END schedule TRIGGER SPECIFIC PART


### PR DESCRIPTION
### Summary :memo:
Adapt base alert policy to be more configurable and create new module with default configurations for BQ executor alerting.

### Details
1. Make base alert policy module be able to handle more than one email address
2. Configure label extractors and email documentation generation on base alert policy 
3. Make a module that has good default values for bq executor

These changes were tested at ANWB

These changes were not tested:
1. The modification of the alert policy generation in `modules/workflows_cf`
2. The default empty label extractor variable in alert policy

I wonder: For the `workflows_cf` module, when instantiated with `trigger_type = "bq"`, do we want only the BQ executor alert based on bigquery errors or also based on cloud function errors? Right now I implement only BQ errors. Cloud function error alerting is only instantiated for `trigger_type != "bq"`
