### PR TITLE
[CD/CD] See plan for staging earlier

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -70,7 +70,7 @@
 #
 #    # Generates an execution plan for Terraform in staging
 #    - name: Terraform Plan Staging
-#      if: github.ref == env.STAGING_REF || github.ref == env.DEVELOPMENT_REF
+#      if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
 #      run: ./helpers/deploy.sh -a plan -s $STAGING_STAGE
 #      env:
 #        GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}


### PR DESCRIPTION
### Summary :memo:
This change allows for seeing the terraform plan for the staging environment from any reference that is not a tag. Basically I wanted to see the plan when I push a feature branch, because in some projects I don't find it worth to also have a development environment alongside the staging one.