### PR TITLE
Remove unnecessary files from Cloud Functions source zip

### DIFF
--- a/terraform/modules/gcs_source/main.tf
+++ b/terraform/modules/gcs_source/main.tf
@@ -8,6 +8,14 @@ data "archive_file" "source" {
   type        = "zip"
   source_dir  = "${path.root}/.."
   output_path = "/tmp/git-function-${local.timestamp}.zip"
+  excludes = concat(
+    tolist(fileset("${path.root}/..", "terraform/**")),
+    tolist(fileset("${path.root}/..", ".git/**")),
+    tolist(fileset("${path.root}/..", ".github/**")),
+    tolist(fileset("${path.root}/..", "docs/**")),
+    tolist(fileset("${path.root}/..", "tests/**")),
+    tolist(fileset("${path.root}/..", "*.md")),
+  )
 }
 
 resource "google_storage_bucket" "bucket" {


### PR DESCRIPTION
### Summary :memo:
Uploads only Python stuff and requirements.txt (and some not important files but they are minimal).

Basically excludes the terraform folder, the .git folder and the .github folder.

This was done in SCF14