### PR TITLE
Shorten name of source bucket

### DIFF
--- a/terraform/modules/gcs_source/main.tf
+++ b/terraform/modules/gcs_source/main.tf
@@ -19,7 +19,7 @@ data "archive_file" "source" {
 }
 
 resource "google_storage_bucket" "bucket" {
-  name     = "${var.project}-${var.app_name}-source"
+  name     = "${var.app_name}-source"
   location = var.region
 }
 


### PR DESCRIPTION
### Summary :memo:
I was having trouble cause the bucket name for the blokker project was too long.... x)
