### PR TITLE
Fix Cloud functions always deploying

### DIFF
--- a/terraform/modules/gcs_source/main.tf
+++ b/terraform/modules/gcs_source/main.tf
@@ -7,7 +7,7 @@ locals {
 data "archive_file" "source" {
   type        = "zip"
   source_dir  = "${path.root}/.."
-  output_path = "/tmp/git-function-${local.timestamp}.zip"
+  output_path = "/tmp/${var.app_name}_source.zip"
   excludes = concat(
     tolist(fileset("${path.root}/..", "terraform/**")),
     tolist(fileset("${path.root}/..", ".git/**")),
@@ -27,6 +27,7 @@ resource "google_storage_bucket_object" "archive" {
   name   = "source.zip#${data.archive_file.source.output_md5}"
   bucket = google_storage_bucket.bucket.name
   source = data.archive_file.source.output_path
+  detect_md5hash = data.archive_file.source.output_md5
 }
 
 output "bucket_name" {

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.58.0"
+      version = "4.84.0"
     }
   }
 }


### PR DESCRIPTION
Cloud functions were updating all the time even if the zip file that contained the code did not change.
This was being caused by 2 things:
* There was a timestamp in the archive file name that triggered an update of the archive file object.
* This in turn generated a file for Google Cloud storage with a different hash
* Additionally, the gcp terraform provider has a bug for the cloud functions resource where the source file `generation` attribute was triggering an update when it was not needed since we track the md5sum of the file in its name.

