### PR TITLE
Preemptively activate eventarc service in bootstrap

### DIFF
--- a/terraform/local-bootstrap-startup/bootstrap_resources.tf
+++ b/terraform/local-bootstrap-startup/bootstrap_resources.tf
@@ -3,7 +3,8 @@ locals {
     cloudbuild = "cloudbuild.googleapis.com",
     cloudresourcemanager = "cloudresourcemanager.googleapis.com",
     iam = "iam.googleapis.com",
-    serviceusage = "serviceusage.googleapis.com"
+    serviceusage = "serviceusage.googleapis.com",
+    eventarc = "eventarc.googleapis.com",
   }
   terraform_permissions = {
     editor = "roles/editor",


### PR DESCRIPTION
### Summary :memo:
@AlexandervbuurenCND  and I just noticed that a timing issue with the eventArc service causes issues when deploying the BQ executor in a new project.

### Problem
The problem is that the event arc API does not seem to be active by the time that a Workflow is created with a trigger.

### What I propose for now
What I propose here goes against best practices but will make this kind of bootstrapping error disappear for now: Let's activate the event arc service preemptively in the bootstrapping part of new projects.

### What we should actually do
If you guys agree we implement this for now and then when one of us has time and remembers to do it we should test that explicitly stating this dependency with the `depends_on` keyword actually works (in my experience it doesn't, but terraform has been evolving so maybe new versions will work). 

Because of how the workflows module is built, we have to interpolate the dependency list and terraform complains about that, so the solution is not immediately straight forward.