### PR TITLE
add time_zone to etl-template workflows as option and variable

### DIFF
--- a/terraform/modules/workflows_cf/main.tf
+++ b/terraform/modules/workflows_cf/main.tf
@@ -238,6 +238,7 @@ resource "google_cloud_scheduler_job" "workflow" {
   name        = "${var.name}-scheduler"
   description = "Cloud Scheduler for Workflow Job ${var.name}"
   schedule    = var.schedule
+  time_zone   = var.time_zone
   region      = var.region
 
   http_target {

--- a/terraform/modules/workflows_cf/variables.tf
+++ b/terraform/modules/workflows_cf/variables.tf
@@ -80,3 +80,9 @@ variable "alert_email_addresses" {
     cnd_alerts = "alerting@cloudninedigital.nl"
   }
 }
+
+variable "time_zone" {
+  description = "The timezone in which to set the schedule."
+  type        = string
+  default     = "Etc/UTC"
+}

--- a/terraform/modules/workflows_cf/variables.tf
+++ b/terraform/modules/workflows_cf/variables.tf
@@ -82,7 +82,7 @@ variable "alert_email_addresses" {
 }
 
 variable "time_zone" {
-  description = "The timezone in which to set the schedule."
+  description = "The timezone in which to set the schedule. For more info on which are valid timezone options, check out https://en.wikipedia.org/wiki/List_of_tz_database_time_zones"
   type        = string
   default     = "Etc/UTC"
 }


### PR DESCRIPTION
### Summary :memo:
_Write an overview about it._
Add the option to set a timezone for the scheduled version of the workflows template.

### Details
_Describe more what you did on changes._
1. add timezone variable with default as UTC
2. add timezone to cloud scheduler trigger with value var.time_zone
